### PR TITLE
Fix error when accessing extra data without setting it first

### DIFF
--- a/example/dj/apps/app/tests/models.py
+++ b/example/dj/apps/app/tests/models.py
@@ -144,3 +144,7 @@ class TokenTestCase(BaseTestCaseMixin, GermaniumTestCase):
         token.save()
         token.refresh_from_db()
         assert_equal(token.get_extra_data(), EXTRA_DATA_2)
+
+        token.extra_data = None
+        token.save()
+        assert_equal(token.get_extra_data(), None)

--- a/verification_token/models.py
+++ b/verification_token/models.py
@@ -107,7 +107,7 @@ class VerificationToken(models.Model):
         self.extra_data = json.dumps(extra_data)
 
     def get_extra_data(self):
-        return json.loads(self.extra_data)
+        return json.loads(self.extra_data) if self.extra_data is not None else None
 
     def save(self, *args, **kwargs):
         if not self.key:


### PR DESCRIPTION
Accessing extra data via the helper method, while `extra_data` is NULL, causes following error:
```
TypeError: the JSON object must be str, bytes or bytearray, not 'NoneType'
```
This PR fixes it.